### PR TITLE
add amdaemon patches for OpenSSL SHA crash bug

### DIFF
--- a/chusanluminous.html
+++ b/chusanluminous.html
@@ -282,6 +282,14 @@
                         patches: [
                             {offset: 0x2bbbc8, off: [0x28], on: [0x08]}
                         ]
+                    },
+                    {
+                        name: "OpenSSL SHA crash bug fix",
+                        tooltip: "Fix crashes on 10th generation and newer Intel CPUs",
+                        patches: [
+                            { offset: 0x4d5643, off: [0x48], on: [0x4c] },
+                            { offset: 0x4d564b, off: [0x48], on: [0x49] }
+                        ]
                     }
                 ]),
                 new Patcher("amdaemon.exe", "2.22.00", [
@@ -297,7 +305,15 @@
                         patches: [
                             {offset: 0x2bafc8, off: [0x28], on: [0x08]}
                         ]
-                    }
+                    },
+                    {
+                        name: "OpenSSL SHA crash bug fix",
+                        tooltip: "Fix crashes on 10th generation and newer Intel CPUs",
+                        patches: [
+                            { offset: 0x4d4a43, off: [0x48], on: [0x4c] },
+                            { offset: 0x4d4a4b, off: [0x48], on: [0x49] },
+                        ]
+                    },
                 ])
             ]);
         });

--- a/chusannew.html
+++ b/chusannew.html
@@ -138,7 +138,15 @@
                         patches: [
                             {offset: 0x2bb928, off: [0x28], on: [0x08]}
                         ]
-                    }
+                    },
+                    {
+                        name: "OpenSSL SHA crash bug fix",
+                        tooltip: "Fix crashes on 10th generation and newer Intel CPUs",
+                        patches: [
+                            { offset: 0x4c3c43, off: [0x48], on: [0x4c] },
+                            { offset: 0x4c3c4b, off: [0x48], on: [0x49] },
+                        ]
+                    },
                 ])
             ]);
         });

--- a/chusannewplus.html
+++ b/chusannewplus.html
@@ -7,90 +7,164 @@
         <script type="text/javascript" src="js/dllpatcher.js"></script>
         <script type="text/javascript">
             window.addEventListener("load", function () {
-            new PatchContainer([
-                new Patcher("chusanApp.exe", "2.05.00", [
-                    {
-                        name: "Disable shop close lockout",
-                        tooltip: "Disables ~12-8am lockout. Does not disable maint lockout from 6:30-7am JST",
-                        patches: [
-                            {offset: 0xB81943, off: [0x74], on: [0xEB]},
-                        ],
-                    },
-                    {
-                        name: "Force shared audio mode, system audio samplerate must be 48000",
-                        tooltip: "Improves compatibility but may increase latency",
-                        patches: [
-                            {offset: 0xE95D2A, off: [0x01], on: [0x00]},
-                        ],
-                    },
-                    {
-                        name: "Force 2 channel audio output",
-                        patches: [
-                            {offset: 0xE95E01, off: [0x75, 0x3F], on: [0x90, 0x90]},
-                        ],
-                    },
-                    {
-                        name: "Disable Song Select Timer",
-                        patches: [
-                            {offset: 0x98455B, off: [0x74], on: [0xEB]},
-                        ],
-                    },
-                    {
-                        name: "Set All Timers to 999",
-                        patches: [
-                            {offset: 0x819940, off: [0x8B, 0x44, 0x24, 0x04, 0x69, 0xC0, 0xE8, 0x03, 0x00, 0x00], on: [0xB8, 0x58, 0x3E, 0x0F, 0x00, 0x90, 0x90, 0x90, 0x90, 0x90]},
-                        ],
-                    },
-                    {
-                        name: "Unlimit Maximum Tracks",
-                        tooltip: "You must check to play more than 7 tracks.",
-                        patches: [
-                            {offset: 0x6CBC89, off: [0xF0], on: [0xC0]},
-                        ],
-                    },
-                    {
-                        type : "number",
-                        name : "Max Tracks",
-                        offset : 0x398381,
-                        size : 4,
-                        min : 1,
-                        max : 12,
-                    },
-                    {
-                        name: "Patch for head-to-head play",
-                        tooltip: "Fix infinite sync while trying to connect to head to head play.",
-                        patches: [
-                            {offset: 0x609FB3, off: [0x01], on: [0x00]},
-                        ]
-                    },
-                    {
-                        name: "No Encryption",
-                        tooltip: "Title server workaround",
-                        patches: [
-                            {offset: 0x1D10640, off: [0xCD], on: [0x00]},
-                            {offset: 0x1D10644, off: [0xCD], on: [0x00]},
-                        ]
-                    },
-                    {
-                        name: "CVT Mode",
-                        danger: "[DEPRECATED] Check to use 60Hz",
-                        patches: [
-                            {offset: 0x1D864, off: [0x01], on: [0x00]},
-                            {offset: 0x1D89B, off: [0x01], on: [0x00]},
-                            {offset: 0x37BBCB, off: [0x75], on: [0xEB]},
-                            {offset: 0x37D6DE, off: [0x84, 0xC0, 0x0F, 0x94, 0xC1], on: [0x90, 0x90, 0x90, 0x90, 0x90]},
-                            {offset: 0xE78E37, off: [0x80], on: [0x00]},
-                        ],
-                    },
-                    {
-                        name: "Bypass LED board check",
-                        danger: "[DEPRECATED] Forces LED board check to good and auto continues",
-                        patches: [
-                            {offset: 0x95790A, off: [0x01], on: [0x00]},
-                            {offset: 0x95790F, off: [0x00], on: [0x01]},
-                        ]
-                    },
-                ])
+                new PatchContainer([
+                    new Patcher("chusanApp.exe", "2.05.00", [
+                        {
+                            name: "Force shared audio mode, system audio sample rate must be 48000Hz",
+                            tooltip: "Improves compatibility, but may increase latency",
+                            patches: [
+                                {offset: 0xe95d2a, off: [0x01], on: [0x00]}
+                            ]
+                        },
+                        {
+                            name: "Force 2 channel audio output",
+                            tooltip: "May cause bass overload",
+                            patches: [
+                                {offset: 0xe95e01, off: [0x75, 0x3f], on: [0x90, 0x90]}
+                            ]
+                        },
+                        {
+                            name: "Disable song select timer",
+                            patches: [
+                                {offset: 0x98455b, off: [0x74], on: [0xeb]}
+                            ]
+                        },
+                        {
+                            name: "Set all timers to 999",
+                            danger: "Breaks online matching functionality",
+                            patches: [
+                                {offset: 0x819940, off: [0x8b, 0x44, 0x24, 0x04, 0x69, 0xc0, 0xe8, 0x03, 0x00, 0x00], on: [0xb8, 0x58, 0x3e, 0x0f, 0x00, 0x90, 0x90, 0x90, 0x90, 0x90]}
+                            ]
+                        },
+                        {
+                            name: "Unlimited maximum tracks",
+                            tooltip: "Must check to play more than 7 tracks per credit",
+                            patches: [
+                                {offset: 0x6cbc89, off: [0xf0], on: [0xc0]}
+                            ]
+                        },
+                        {
+                            type: "number",
+                            name: "Maximum tracks",
+                            offset: 0x398381,
+                            size: 4,
+                            min: 3,
+                            max: 12
+                        },
+                        {
+                            name: "No encryption",
+                            tooltip: "Will also disable TLS",
+                            patches: [
+                                {offset: 0x1d10640, off: [0xcd], on: [0x00]},
+                                {offset: 0x1d10644, off: [0xcd], on: [0x00]}
+                            ]
+                        },
+                        {
+                            name: "No TLS",
+                            tooltip: "Title server workaround",
+                            patches: [
+                                {offset: 0xe78e37, off: [0x80], on: [0x00]}
+                            ]
+                        },
+                        {
+                            name: "Patch for head-to-head play",
+                            tooltip: "Fix infinite sync while trying to connect to head to head play",
+                            patches: [
+                                {offset: 0x609fb3, off: [0x01], on: [0x00]}
+                            ]
+                        },
+                        {
+                            name: "Bypass 1080p monitor check",
+                            patches: [
+                                {offset: 0x1d81f, off: [0x81, 0xbc, 0x24, 0xb8, 0x02, 0x00, 0x00, 0x80, 0x07, 0x00, 0x00, 0x75, 0x1f, 0x81, 0xbc, 0x24, 0xbc, 0x02, 0x00, 0x00, 0x38, 0x04, 0x00, 0x00, 0x75, 0x12], on: [0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90]}
+                            ]
+                        },
+                        {
+                            name: "Bypass 120Hz monitor check",
+                            patches: [
+                                {offset: 0x1d811, off: [0x85, 0xc0], on: [0xeb, 0x30]}
+                            ]
+                        },
+                        {
+                            name: "Force FREE PLAY credit text",
+                            tooltip: "Replaces the credit count with FREE PLAY",
+                            patches: [
+                                {offset: 0x387824, off: [0x3c, 0x01], on: [0x38, 0xc0]}
+                            ]
+                        },
+                        {
+                            type: "hex",
+                            name: "Custom FREE PLAY text",
+                            tooltip: "Replace the FREE PLAY text when using Infinite credits",
+                            offset: 0x192fc24,
+                            off: [0x46, 0x52, 0x45, 0x45, 0x20, 0x50, 0x4c, 0x41, 0x59],
+                        },
+                        {
+                            name: "Disable shop close lockout",
+                            danger: "[DEPRECATED] Just disable it in the test menu",
+                            patches: [
+                                {offset: 0xb81943, off: [0x74], on: [0xeb]}
+                            ]
+                        },
+                        {
+                            name: "Bypass LED board check",
+                            danger: "[DEPRECATED] Forces LED board check to good and auto continues",
+                            patches: [
+                                {offset: 0x95790a, off: [0x01], on: [0x00]},
+                                {offset: 0x95790f, off: [0x00], on: [0x01]}
+                            ]
+                        },
+                        {
+                            name: "Ignore some errors from amdaemon",
+                            danger: "[DEPRECATED] May relieve some errors like error 6401, but may also cause problems elsewhere.",
+                            patches: [
+                                {offset: 0x37dfcb, off: [0x75], on: [0xeb]}
+                            ]
+                        }
+                    ])
+                ]);
+                new PatchContainer([
+                    new Patcher("amdaemon.exe", "2.05.00", [
+                        {
+                            name: "Allow 127.0.0.1/localhost as the network server",
+                            patches: [
+                                {
+                                    offset: 0x3B6EF4,
+                                    off: [0xFF, 0x15, 0x3E, 0x79, 0x1A, 0x00, 0x8B],
+                                    on: [0x33, 0xC0, 0x48, 0x83, 0xC4, 0x28, 0xC3],
+                                },
+                                {
+                                    offset: 0x6BC83C,
+                                    off: [0x31, 0x32, 0x37, 0x2F],
+                                    on: [0x30, 0x2F, 0x38, 0x00],
+                                },
+                            ],
+                        },
+                        {
+                            name: "Free Play",
+                            tooltip: "Endless credits",
+                            patches: [
+                                { offset: 0x2BB928, off: [0x28], on: [0x08] },
+                            ]
+                        },
+                        {
+                            name: "OpenSSL SHA crash bug fix",
+                            tooltip: "Fix crashes on 10th generation and newer Intel CPUs",
+                            patches: [
+                                { offset: 0x4c3c43, off: [0x48], on: [0x4c] },
+                                { offset: 0x4c3c4b, off: [0x48], on: [0x49] },
+                            ]
+                        },
+                        {
+                            name: "Replace error 6401 with no error",
+                            danger: "[DEPRECATED] Sets all instances of error 6401 to 0",
+                            patches: [
+                                { offset: 0x2220F6, off: [0x01, 0x19], on: [0x00, 0x00] },
+                                { offset: 0x22229E, off: [0x01, 0x19], on: [0x00, 0x00] },
+                                { offset: 0x222C87, off: [0x01, 0x19], on: [0x00, 0x00] },
+                            ],
+                        },
+                    ])
                 ]);
             });
         </script>

--- a/chusansun.html
+++ b/chusansun.html
@@ -140,6 +140,14 @@
                         ]
                     },
                     {
+                        name: "OpenSSL SHA crash bug fix",
+                        tooltip: "Fix crashes on 10th generation and newer Intel CPUs",
+                        patches: [
+                            { offset: 0x4c3c43, off: [0x48], on: [0x4c] },
+                            { offset: 0x4c3c4b, off: [0x48], on: [0x49] },
+                        ]
+                    },
+                    {
                         name: "Replace error 6401 with no error",
                         danger: "[DEPRECATED] Sets all instances of error 6401 to 0",
                         patches: [

--- a/chusansunplus.html
+++ b/chusansunplus.html
@@ -140,6 +140,14 @@
                         ]
                     },
                     {
+                        name: "OpenSSL SHA crash bug fix",
+                        tooltip: "Fix crashes on 10th generation and newer Intel CPUs",
+                        patches: [
+                            { offset: 0x4c3c43, off: [0x48], on: [0x4c] },
+                            { offset: 0x4c3c4b, off: [0x48], on: [0x49] },
+                        ]
+                    },
+                    {
                         name: "Replace error 6401 with no error",
                         danger: "[DEPRECATED] Sets all instances of error 6401 to 0",
                         patches: [


### PR DESCRIPTION
not actually tested since I don't own an 10th Gen+ CPU, but at least amdaemon doesn't crash on my 8th Gen CPU.

Reference: https://eamonwoortman.github.io/openssl-binary-patching/

